### PR TITLE
fix some words traslation error (#1)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,10 @@ const spinner = input => {
     return res;
 })(commands[0]).then(r => {
     let msg = JSON.parse(r.body);
-    process.spinner.succeed(msg.basic.explains[0]);
+    if (msg.basic) {
+        process.spinner.succeed(msg.basic.explains[0]);
+    } else {
+        process.spinner.succeed(msg.translation[0]);
+    }
 })
 


### PR DESCRIPTION
Not every words translated with result from Youdao API has the `basic.explains` json body. (e.g.: when translating the word `test`.)
So just show their translation array message.